### PR TITLE
only set BEARER_TOKEN in subshells, not in the current process, so we…

### DIFF
--- a/ifdh.cfg
+++ b/ifdh.cfg
@@ -531,7 +531,7 @@ strip_file_prefix=0
 extra_env=IFDH_ROOT_EXTRA
 extra_env_2=IFDH_XROOT_EXTRA
 #cp_cmd=xrdcp –DIRedirectLimit 255 -DIRequestTimeout 14400 --tpc first --force %(extra)s %(src)s %(dst)s
-cp_cmd=xrdcp -DIRequestTimeout 14400 --tpc first --force  %(extra)s %(src)s %(dst)s
+cp_cmd=[ -s ${BEARER_TOKEN_FILE:-/dev/null} ] && export BEARER_TOKEN=`cat ${BEARER_TOKEN_FILE}`; xrdcp -DIRequestTimeout 14400 --tpc first --force  %(extra)s %(src)s %(dst)s
 lss_cmd=xrdwrap.sh ls -l %(src)s
 lss_skip=0
 lss_size_last=0

--- a/ifdh/ifdh_cp.cc
+++ b/ifdh/ifdh_cp.cc
@@ -908,7 +908,6 @@ get_grid_credentials_if_needed() {
         }
     }
 
-    bool found_token;
     if (tokens_enabled && !check_grid_credentials_tokens() && have_kerberos_creds() ) {
         ifdh::_debug && std::cerr << "no grid credentials: tokens:\n";
         setenv("BEARER_TOKEN_FILE", tokenfile.str().c_str(),1);
@@ -955,7 +954,6 @@ get_grid_credentials_if_needed() {
 
         if (res == 0) {
            found = true;
-           found_token = true;
         }
 
         if ((!WIFEXITED(res) ||  0 != WEXITSTATUS(res)) && res != 256) {
@@ -964,27 +962,11 @@ get_grid_credentials_if_needed() {
         }
     } else if (tokens_enabled) { 
         found = true;
-        found_token = true;
     }
   
     if (!found) {
         std::cerr << (time(&gt)?ctime(&gt):"") << " ";
         std::cerr << "Notice: Unable to find valid grid or kerberos credentials. Later actions will likely fail."<< endl;
-    }
-    if( found_token ) {
-        //
-        // turns out gfal utilities *only* believe 
-        // BEARER_TOKEN in the environment and do not read
-        // BEARER_TOKEN_FILE, etc... 
-        // https://dmc-docs.web.cern.ch/dmc-docs/developers/bearer-tokens.html
-        // so read the token file and set BEARER_TOKEN, as well.
-        //
-        const int maxtoken = 8192;
-        static char tokenbuf[maxtoken+1];
-        std::ifstream btf(tokenfile.str().c_str());
-        btf.read(tokenbuf, maxtoken);
-        btf.close();
-        setenv("BEARER_TOKEN", tokenbuf, 1);
     }
 }
 

--- a/ifdh/xrdwrap.sh
+++ b/ifdh/xrdwrap.sh
@@ -31,6 +31,9 @@ done
 
 args="'$host' $args"
 
+# set BEARER_TOKEN for older versions
+[ -s ${BEARER_TOKEN_FILE:-/dev/null} ] && export BEARER_TOKEN=`cat ${BEARER_TOKEN_FILE}`
+
 #
 # annoyingly xrdfs does not do ls of files, it gives
 # an error, so if we're asked to ls something that is


### PR DESCRIPTION
… don't break non-ifdh use of other tools by holding onto an old token.

This also stops sometimes setting BEARER_TOKEN to a bad token due to uninitialized boolean token_found.