### PR TITLE
better debug messages regarding grid credential checks

### DIFF
--- a/ifdh/Makefile
+++ b/ifdh/Makefile
@@ -3,7 +3,7 @@ SRCDIR=../../ifdh/
 VPATH=$(SRCDIR)
 
 #
-# Note: set PYTHON=python3 and PYMAJOR=3 to build a system python3 version
+# Note: set PYTHON=python3 PYMAJOR=3 PYTHON_INCLUDE=/usr/includ/python3.9 to build a system python3 version
 #       set PYTHON_INCLUDE, PYTHON_LIB, and PYMAJOR to use non-system python.
 #
 

--- a/ifdh/ifdh_cp.cc
+++ b/ifdh/ifdh_cp.cc
@@ -614,7 +614,7 @@ get_grid_credentials_if_needed() {
     bool found = false;
     int res;
 
-    ifdh::_debug && std::cerr << "Checking for proxy cert..."<< endl;
+    ifdh::_debug && std::cerr << "Checking for grid credentials..."<< endl;
 
     int proxies_enabled = ifdh::_config.getint("proxies","enabled");
     int tokens_enabled = ifdh::_config.getint("tokens","enabled");
@@ -631,8 +631,11 @@ get_grid_credentials_if_needed() {
     }
 
     if( (getenv("IFDH_NO_PROXY") && 0 != strlen(getenv("IFDH_NO_PROXY"))) || 
-           (!proxies_enabled && !tokens_enabled) )
+           (!proxies_enabled && !tokens_enabled) ) {
+        
+        ifdh::_debug && std::cerr << "...checks disabled by IFDH_NO_PROXY/--no_proxy" << endl;
         return;
+    }
    
     // define strings for things we need...
     string role;

--- a/util/ifdh_version.h
+++ b/util/ifdh_version.h
@@ -1,1 +1,1 @@
-#define IFDH_VERSION "v2_8_0"
+#define IFDH_VERSION "v2_8_0-6-g4bb07c0"

--- a/util/ifdh_version.h
+++ b/util/ifdh_version.h
@@ -1,1 +1,1 @@
-#define IFDH_VERSION "v2_8_0-6-g4bb07c0"
+#define IFDH_VERSION "v2_8_0-9-g36d5585"

--- a/util/ifdh_version.h
+++ b/util/ifdh_version.h
@@ -1,1 +1,1 @@
-#define IFDH_VERSION "v2_8_0-9-g36d5585"
+#define IFDH_VERSION "v2_8_0"


### PR DESCRIPTION
Current debug message of "Checking for proxy cert..." was confusing, as
* we generally don't support proxies anymore
* it printed it even when --no_proxy was passed to disable checks

Now says:

```
Checking for grid credentials...
...checks disabled by IFDH_NO_PROXY/--no_proxy
```

if you pass in --no_proxy=1 and the later messages are specific about whether they are checking tokens or proxies, if --no_proxy is not set. 